### PR TITLE
Issue/553

### DIFF
--- a/src/components/event/EventFormSummary.vue
+++ b/src/components/event/EventFormSummary.vue
@@ -35,7 +35,9 @@
     </SummaryItem>
     <SummaryItem>
       <SummaryItemCaption>Place</SummaryItemCaption>
-      <SummaryItemText>{{ place }}</SummaryItemText>
+      <SummaryItemText>
+        <event-place :place="place" />
+      </SummaryItemText>
       <SummaryItemSubtext v-if="!isPrivate">
         <v-icon :color="sharedRoomIcon.color">{{ sharedRoomIcon.icon }}</v-icon>
         {{ sharedRoomString }}
@@ -60,7 +62,7 @@ import SummaryItemMain from '@/components/shared/SummaryItemMain.vue'
 import SummaryItemText from '@/components/shared/SummaryItemText.vue'
 import SummaryItemSubtext from '@/components/shared/SummaryItemSubtext.vue'
 import { formatDate, DATETIME_DISPLAY_FORMAT } from '@/workers/date'
-
+import EventPlace from '@/components/event/EventPlace.vue'
 export type EventSummary = {
   name: string
   description: string
@@ -83,6 +85,7 @@ export type EventSummary = {
     SummaryItemMain,
     SummaryItemText,
     SummaryItemSubtext,
+    EventPlace,
   },
 })
 export default class EventFormSummary extends Vue {

--- a/src/components/event/EventPlace.vue
+++ b/src/components/event/EventPlace.vue
@@ -1,13 +1,11 @@
 <template>
-  <div>
-    <div>
-      <v-icon v-if="contains('youtube')" class="mr-1">mdi-youtube</v-icon>
-      <v-icon v-if="contains('discord')" class="mr-1">mdi-discord</v-icon>
-      <v-icon v-if="contains('zoom')" class="mr-1">mdi-video</v-icon>
-      <v-icon v-if="contains('qall')" class="mr-1">mdi-phone</v-icon>
-      {{ place }}
-    </div>
-  </div>
+  <span>
+    <v-icon v-if="contains('youtube')" class="mr-1">mdi-youtube</v-icon>
+    <v-icon v-if="contains('discord')" class="mr-1">mdi-discord</v-icon>
+    <v-icon v-if="contains('zoom')" class="mr-1">mdi-video</v-icon>
+    <v-icon v-if="contains('qall')" class="mr-1">mdi-phone</v-icon>
+    {{ place }}
+  </span>
 </template>
 
 <script lang="ts">

--- a/src/components/event/EventPlace.vue
+++ b/src/components/event/EventPlace.vue
@@ -18,7 +18,7 @@ export default class EventPlace extends Vue {
   place!: string
 
   contains(searchWord: string): boolean {
-    return this.place.toLowerCase().indexOf(searchWord) !== -1
+    return this.place.toLowerCase().includes(searchWord)
   }
 }
 </script>

--- a/src/components/event/EventPlace.vue
+++ b/src/components/event/EventPlace.vue
@@ -1,0 +1,24 @@
+<template>
+  <div>
+    <v-icon v-if="contains('youtube')" class="mb-1">mdi-youtube</v-icon>
+    <v-icon v-if="contains('discord')" class="mb-1">mdi-discord</v-icon>
+    <v-icon v-if="contains('zoom')" class="mb-1">mdi-video</v-icon>
+    <v-icon v-if="contains('qall')" class="mb-1">mdi-phone</v-icon>
+    {{ place }}
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import { Component, Prop } from 'vue-property-decorator'
+
+@Component
+export default class EventPlace extends Vue {
+  @Prop({ type: String, required: true })
+  place!: string
+
+  contains(searchWord: string): boolean {
+    return this.place.toLowerCase().indexOf(searchWord) !== -1
+  }
+}
+</script>

--- a/src/components/event/EventPlace.vue
+++ b/src/components/event/EventPlace.vue
@@ -1,10 +1,12 @@
 <template>
   <div>
-    <v-icon v-if="contains('youtube')" class="mb-1">mdi-youtube</v-icon>
-    <v-icon v-if="contains('discord')" class="mb-1">mdi-discord</v-icon>
-    <v-icon v-if="contains('zoom')" class="mb-1">mdi-video</v-icon>
-    <v-icon v-if="contains('qall')" class="mb-1">mdi-phone</v-icon>
-    {{ place }}
+    <div>
+      <v-icon v-if="contains('youtube')" class="mr-1">mdi-youtube</v-icon>
+      <v-icon v-if="contains('discord')" class="mr-1">mdi-discord</v-icon>
+      <v-icon v-if="contains('zoom')" class="mr-1">mdi-video</v-icon>
+      <v-icon v-if="contains('qall')" class="mr-1">mdi-phone</v-icon>
+      {{ place }}
+    </div>
   </div>
 </template>
 

--- a/src/pages/EventDetail.vue
+++ b/src/pages/EventDetail.vue
@@ -89,7 +89,9 @@
           >
             {{ event.room.place }}
           </a>
-          <span v-else class="mr-3">{{ event.room.place }}</span>
+          <span v-else class="mr-3">
+            <event-place :place="event.room.place"></event-place>
+          </span>
         </div>
         <div v-if="event.room.verified" class="text--secondary body-2">
           <v-icon :color="sharedRoomIcon.color">
@@ -129,6 +131,8 @@ import AttendanceForm from '@/components/event/AttendanceForm.vue'
 import EventAttendees from '@/components/event/EventAttendees.vue'
 import { formatDate, DATETIME_DISPLAY_FORMAT } from '@/workers/date'
 import { isTitechRoom, calcRoomPdfUrl } from '@/workers/TokyoTech'
+import EventPlace from '@/components/event/EventPlace.vue'
+
 import api, {
   ResponseEventDetail,
   ResponseUser,
@@ -146,6 +150,7 @@ import api, {
     EventAttendees,
     UserAvatar,
     AttendanceForm,
+    EventPlace,
   },
 })
 export default class EventDetail extends Vue {


### PR DESCRIPTION
"Discord", "YouTube", "Qall", "zoom"(大文字, 小文字を区別しない)が場所名に含まれていると, 対応するアイコンが場所名の前に表示される