### PR TITLE
fix: いらなくなったイベントを削除するように

### DIFF
--- a/src/pages/Calendar.vue
+++ b/src/pages/Calendar.vue
@@ -30,6 +30,7 @@ export default class CalendarPage extends Vue {
 
   async fetchMonthlyEvents(newDate) {
     this.status = 'loading'
+    this.events = []
     const startDate = new Date(newDate.getFullYear(), newDate.getMonth(), 1)
     const endDate = new Date(newDate.getFullYear(), newDate.getMonth() + 1, 0)
     try {

--- a/src/pages/Calendar.vue
+++ b/src/pages/Calendar.vue
@@ -31,8 +31,10 @@ export default class CalendarPage extends Vue {
   async fetchMonthlyEvents(newDate) {
     this.status = 'loading'
     this.events = []
-    const startDate = new Date(newDate.getFullYear(), newDate.getMonth(), 1)
+    const startDate = new Date(newDate.getFullYear(), newDate.getMonth() - 1, 1)
     const endDate = new Date(newDate.getFullYear(), newDate.getMonth() + 2, 0)
+    console.log(startDate)
+    console.log(endDate)
     try {
       this.events = await api.events.getEvents({
         dateBegin: startDate.toISOString(),

--- a/src/pages/Calendar.vue
+++ b/src/pages/Calendar.vue
@@ -33,8 +33,6 @@ export default class CalendarPage extends Vue {
     this.events = []
     const startDate = new Date(newDate.getFullYear(), newDate.getMonth() - 1, 1)
     const endDate = new Date(newDate.getFullYear(), newDate.getMonth() + 2, 0)
-    console.log(startDate)
-    console.log(endDate)
     try {
       this.events = await api.events.getEvents({
         dateBegin: startDate.toISOString(),

--- a/src/pages/Calendar.vue
+++ b/src/pages/Calendar.vue
@@ -32,7 +32,7 @@ export default class CalendarPage extends Vue {
     this.status = 'loading'
     this.events = []
     const startDate = new Date(newDate.getFullYear(), newDate.getMonth(), 1)
-    const endDate = new Date(newDate.getFullYear(), newDate.getMonth() + 1, 0)
+    const endDate = new Date(newDate.getFullYear(), newDate.getMonth() + 2, 0)
     try {
       this.events = await api.events.getEvents({
         dateBegin: startDate.toISOString(),


### PR DESCRIPTION
https://github.com/traPtitech/knoQ/issues/570
を解決する過程で，今のままだと過去の月で取得した複数日開催のイベントが配列に残ってしまっていて見栄えが悪いことに気がついたので，毎回配列をからにするようにしました。