### PR TITLE
月末の予定を取得できるように

### DIFF
--- a/src/pages/Calendar.vue
+++ b/src/pages/Calendar.vue
@@ -32,7 +32,7 @@ export default class CalendarPage extends Vue {
     this.status = 'loading'
     this.events = []
     const startDate = new Date(newDate.getFullYear(), newDate.getMonth() - 1, 1)
-    const endDate = new Date(newDate.getFullYear(), newDate.getMonth() + 2, 0)
+    const endDate = new Date(newDate.getFullYear(), newDate.getMonth() + 2, 0, 23, 59, 59)
     try {
       this.events = await api.events.getEvents({
         dateBegin: startDate.toISOString(),


### PR DESCRIPTION
30 日までしかない 11 月だと、スケジュールの取得範囲が YYYY-11-30T00:00:00+09:00 までしかできなくなっていたので、これを 23:59:59 まで拡張した