### PR TITLE
Feat/set default end time

### DIFF
--- a/src/components/event/EventFormBase.vue
+++ b/src/components/event/EventFormBase.vue
@@ -77,6 +77,7 @@ import FormNextButton from '@/components/shared/FormNextButton.vue'
 import FormBackButton from '@/components/shared/FormBackButton.vue'
 import { useDraftConfirmer } from '@/workers/draftConfirmer'
 import { removeDraftConfirmer } from '@/workers/draftConfirmer'
+import { today } from '@/workers/date'
 import router from '@/router'
 import { Route } from 'vue-router'
 
@@ -126,6 +127,20 @@ export default class EventFormBase extends Vue {
 
   beforeEachControl: (() => void) | null = null
 
+  roundToNextHour(date: Date): Date {
+    const roundedDate = new Date(date)
+    const minutes = roundedDate.getMinutes()
+    const seconds = roundedDate.getSeconds()
+    const milliseconds = roundedDate.getMilliseconds()
+
+    if (minutes > 0 || seconds > 0 || milliseconds > 0) {
+      roundedDate.setHours(roundedDate.getHours() + 1)
+    }
+    roundedDate.setMinutes(0, 0, 0)
+
+    return roundedDate
+  }
+
   created() {
     this.content = {
       name: this.event?.name ?? '',
@@ -149,8 +164,15 @@ export default class EventFormBase extends Vue {
           : true,
     }
     this.timeAndPlaceInstant = {
-      timeStart: this.event?.instant ? this.event.timeStart ?? '' : '',
-      timeEnd: this.event?.instant ? this.event.timeEnd ?? '' : '',
+      // TODO: placeだけ初期値がないとvalidationが先に走ってしまう
+      timeStart: this.event?.instant
+        ? this.event.timeStart ?? ''
+        : this.roundToNextHour(new Date()).toISOString(),
+      timeEnd: this.event?.instant
+        ? this.event.timeEnd ?? ''
+        : this.roundToNextHour(
+            new Date(new Date().getTime() + 60 * 60 * 1000)
+          ).toISOString(),
       place: this.event?.instant ? this.event.place ?? '' : '',
     }
     this.instant = this.event?.instant ?? false

--- a/src/components/event/EventFormTimeAndPlaceInstant.vue
+++ b/src/components/event/EventFormTimeAndPlaceInstant.vue
@@ -77,8 +77,7 @@ export default class EventFormTimeAndPlaceInstant extends Vue {
   private timeStartMem = ''
   private timeEndMem = ''
   private dateDiff = 0
-  private hourDiff = 1
-  private minuteDiff = 0
+  private minuteDiff = 60
 
   @Ref()
   readonly form!: { validate(): void }
@@ -141,25 +140,35 @@ export default class EventFormTimeAndPlaceInstant extends Vue {
 
   public autoFillTimeEnd() {
     if (!this.timeEndMem) {
-      this.hourDiff = 1
-      this.minuteDiff = 0
+      this.minuteDiff = 60
     }
-    const [startHour, startMinute] = this.timeStartMem.split(':').map(Number)
-    let endMinute = startMinute + this.minuteDiff
-    let endHour = startHour + this.hourDiff
 
-    if (endMinute >= 60) {
-      endHour += 1
-      endMinute -= 60
+    let endTime = new Date(this.timeStartInput)
+
+    endTime.setMinutes(endTime.getMinutes() + this.minuteDiff)
+
+    const endHour = endTime.getHours()
+    const endMinute = endTime.getMinutes()
+
+    // 正の向きに日付を跨いだかどうかの判定
+    if (endTime.getDate() - new Date(this.timeStartInput).getDate() > 0) {
+      let startDate = new Date(this.dateEndMem)
+      let endDate = startDate
+      endDate.setDate(startDate.getDate() + 1)
+      this.dateEndMem = endDate.toISOString().split('T')[0]
     }
-    if (endHour >= 24) {
-      endHour -= 24
+    // 負の向きに日付を跨いだかどうかの判定
+    else if (endTime.getDate() - new Date(this.timeEndInput).getDate() < 0) {
+      let startDate = new Date(this.dateEndMem)
+      let endDate = startDate
+      endDate.setDate(startDate.getDate() - 1)
+      this.dateEndMem = endDate.toISOString().split('T')[0]
     }
+
     this.timeEndMem = `${String(endHour).padStart(2, '0')}:${String(
       endMinute
     ).padStart(2, '0')}`
   }
-
   public calcDateDiff() {
     if (this.dateStartMem && this.dateEndMem) {
       const startDate = new Date(this.dateStartMem)
@@ -181,14 +190,12 @@ export default class EventFormTimeAndPlaceInstant extends Vue {
       const endDateTime = new Date(`${this.dateEndMem}T${this.timeEndMem}`)
       const diffInMilliseconds = endDateTime.getTime() - startDateTime.getTime()
       if (diffInMilliseconds > 0) {
-        this.hourDiff = Math.floor(diffInMilliseconds / (1000 * 60 * 60)) % 24
-        this.minuteDiff = Math.floor(diffInMilliseconds / (1000 * 60)) % 60
+        this.minuteDiff = Math.floor(diffInMilliseconds / (1000 * 60))
       } else {
-        this.hourDiff = 0
         this.minuteDiff = 0
       }
     }
-    console.log(this.hourDiff, this.minuteDiff)
+    console.log(this.minuteDiff)
   }
 }
 </script>

--- a/src/components/event/EventFormTimeAndPlaceInstant.vue
+++ b/src/components/event/EventFormTimeAndPlaceInstant.vue
@@ -141,6 +141,7 @@ export default class EventFormTimeAndPlaceInstant extends Vue {
     }
   }
 
+  // TODO:やっぱり日付を跨いだ時の処理がおかしい
   public autoFillTimeEnd() {
     if (!this.timeEndMem) {
       this.minuteDiff = 60

--- a/src/components/event/EventFormTimeAndPlaceInstant.vue
+++ b/src/components/event/EventFormTimeAndPlaceInstant.vue
@@ -126,15 +126,18 @@ export default class EventFormTimeAndPlaceInstant extends Vue {
     }
   }
 
+  private ajustDate(dateStr: string, days: number): string {
+    let date = new Date(dateStr)
+    date.setDate(date.getDate() + days)
+    return date.toISOString().split('T')[0]
+  }
+
   public autoFillDateEnd() {
     if (!this.dateEndMem) {
       this.dateDiff = 0
       this.dateEndMem = this.dateStartMem
     } else {
-      let startDate = new Date(this.dateStartMem)
-      let endDate = startDate
-      endDate.setDate(startDate.getDate() + this.dateDiff)
-      this.dateEndMem = endDate.toISOString().split('T')[0]
+      this.dateEndMem = this.ajustDate(this.dateStartMem, this.dateDiff)
     }
   }
 
@@ -144,31 +147,24 @@ export default class EventFormTimeAndPlaceInstant extends Vue {
     }
 
     let endTime = new Date(this.timeStartInput)
-
     endTime.setMinutes(endTime.getMinutes() + this.minuteDiff)
-
-    const endHour = endTime.getHours()
-    const endMinute = endTime.getMinutes()
 
     // 正の向きに日付を跨いだかどうかの判定
     if (endTime.getDate() - new Date(this.timeStartInput).getDate() > 0) {
-      let startDate = new Date(this.dateEndMem)
-      let endDate = startDate
-      endDate.setDate(startDate.getDate() + 1)
-      this.dateEndMem = endDate.toISOString().split('T')[0]
+      this.dateEndMem = this.ajustDate(this.dateEndMem, 1)
     }
     // 負の向きに日付を跨いだかどうかの判定
     else if (endTime.getDate() - new Date(this.timeEndInput).getDate() < 0) {
-      let startDate = new Date(this.dateEndMem)
-      let endDate = startDate
-      endDate.setDate(startDate.getDate() - 1)
-      this.dateEndMem = endDate.toISOString().split('T')[0]
+      this.dateEndMem = this.ajustDate(this.dateEndMem, -1)
     }
 
+    const endHour = endTime.getHours()
+    const endMinute = endTime.getMinutes()
     this.timeEndMem = `${String(endHour).padStart(2, '0')}:${String(
       endMinute
     ).padStart(2, '0')}`
   }
+
   public calcDateDiff() {
     if (this.dateStartMem && this.dateEndMem) {
       const startDate = new Date(this.dateStartMem)

--- a/src/components/event/EventFormTimeAndPlaceInstant.vue
+++ b/src/components/event/EventFormTimeAndPlaceInstant.vue
@@ -76,8 +76,6 @@ export default class EventFormTimeAndPlaceInstant extends Vue {
   private dateEndMem = ''
   private timeStartMem = ''
   private timeEndMem = ''
-  private yearDiff = 0
-  private monthDiff = 0
   private dateDiff = 0
   private hourDiff = 1
   private minuteDiff = 0
@@ -131,16 +129,11 @@ export default class EventFormTimeAndPlaceInstant extends Vue {
 
   public autoFillDateEnd() {
     if (!this.dateEndMem) {
-      this.dateEndMem = this.dateStartMem
-      this.yearDiff = 0
-      this.monthDiff = 0
       this.dateDiff = 0
+      this.dateEndMem = this.dateStartMem
     } else {
-      const startDate = new Date(this.dateStartMem)
-      const endDate = new Date(this.dateEndMem)
-
-      endDate.setFullYear(startDate.getFullYear() + this.yearDiff)
-      endDate.setMonth(startDate.getMonth() + this.monthDiff)
+      let startDate = new Date(this.dateStartMem)
+      let endDate = startDate
       endDate.setDate(startDate.getDate() + this.dateDiff)
       this.dateEndMem = endDate.toISOString().split('T')[0]
     }
@@ -171,20 +164,6 @@ export default class EventFormTimeAndPlaceInstant extends Vue {
     if (this.dateStartMem && this.dateEndMem) {
       const startDate = new Date(this.dateStartMem)
       const endDate = new Date(this.dateEndMem)
-
-      this.yearDiff = endDate.getFullYear() - startDate.getFullYear()
-      if (this.yearDiff < 0) {
-        this.yearDiff = 0
-      }
-
-      this.monthDiff =
-        endDate.getMonth() -
-        startDate.getMonth() +
-        12 * (endDate.getFullYear() - startDate.getFullYear())
-      if (this.monthDiff < 0) {
-        this.monthDiff = 0
-      }
-
       this.dateDiff = Math.floor(
         (endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)
       )


### PR DESCRIPTION
イベント作成における日時のautocompleteのロジックを改善しました。
具体的には，デフォルトでは終了日時が開始日時+0日1時間となるように自動で値を埋めるようにしました。また，その後ユーザーが終了日時の方をいじったあとに開始日時を変更した場合，変更する直前の終了日時と開始日時の差を保つようにして終了日時を自動で変更するようにしました。

既知の問題として，開始日→開始時刻以外の順番で入力されるとautocompleteがうまくいかないというものがあります。これについては，何らかの方法によって日付の初期値を設定できると良いかと思っています。
(今日の日付を入れる？あるいはカレンダーから日付を選択してイベントを入れられるようにする？)