### PR TITLE
画面幅が狭い時はボタンをアイコンだけにする

### DIFF
--- a/src/components/shared/Calendar.vue
+++ b/src/components/shared/Calendar.vue
@@ -2,21 +2,18 @@
   <div>
     <v-sheet :height="status === 'loading' ? 60 : 64">
       <v-toolbar flat>
-        <v-btn
-          outlined
-          class="mr-4"
-          color="grey darken-2"
-          @click="jumpToCurrentDate"
-        >
+        <v-btn outlined color="grey darken-2" @click="jumpToCurrentDate">
           <v-icon v-if="buttonSlim"> mdi-calendar-today-outline </v-icon>
           <span v-else> Today </span>
         </v-btn>
-        <v-btn fab text small color="grey darken-2" @click="prev">
-          <v-icon small> mdi-chevron-left </v-icon>
-        </v-btn>
-        <v-btn fab text small color="grey darken-2" @click="next">
-          <v-icon small> mdi-chevron-right </v-icon>
-        </v-btn>
+        <div class="mx-2">
+          <v-btn fab text small color="grey darken-2" @click="prev">
+            <v-icon small> mdi-chevron-left </v-icon>
+          </v-btn>
+          <v-btn fab text small color="grey darken-2" @click="next">
+            <v-icon small> mdi-chevron-right </v-icon>
+          </v-btn>
+        </div>
         <v-toolbar-title v-if="$refs.calendar">
           {{ calendarTitle }}
         </v-toolbar-title>


### PR DESCRIPTION
ボタンが幅を取りすぎてスマホだと見切れていたので, アイコンだけにしました.

Todayの代わりに `mdi-calendar-today-outline` を置きましたが, ぱっと見で分からないかも...?というのが懸念点です.

<img width="412" height="915" alt="image" src="https://github.com/user-attachments/assets/68ac48ae-b448-4215-a889-984e04bf321a" />
<img width="412" height="915" alt="image" src="https://github.com/user-attachments/assets/7752919b-e63b-4abb-b21d-46ff231ecbef" />
